### PR TITLE
Reactor의 테스트를 위해 필수 권한 목록을 주입 받도록 변경

### DIFF
--- a/Absinthe/Absinthe.xcodeproj/project.pbxproj
+++ b/Absinthe/Absinthe.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05E36357C969FB1349524452196E98C1 /* AbsinthePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5D9E899DAEB7C90FB834E5F6EBD75 /* AbsinthePolicy.swift */; };
 		304DFDAB11588943050F33C943A60C16 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2689B0AB1AB2884CDB6F71264706FBC2 /* Presenter.swift */; };
 		55B93A6AB1A9B65807EAD7F52138C671 /* ContainerSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C172372356F31B60A9F218710853D262 /* ContainerSetUp.swift */; };
 		691097229BD06580541E2C4C45139C6C /* ViewModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A005250E156C2BB269AB10005BCD4F63 /* ViewModel.framework */; };
@@ -46,6 +47,7 @@
 		C05FBFB2F0E22EAEBC5B98099D5F485E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C172372356F31B60A9F218710853D262 /* ContainerSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerSetUp.swift; sourceTree = "<group>"; };
 		C18DCE9D39626A293046F90C4671F2DF /* Pods-Absinthe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Absinthe.release.xcconfig"; path = "Target Support Files/Pods-Absinthe/Pods-Absinthe.release.xcconfig"; sourceTree = "<group>"; };
+		E1E5D9E899DAEB7C90FB834E5F6EBD75 /* AbsinthePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbsinthePolicy.swift; sourceTree = "<group>"; };
 		E7E1AC6A5196ECAB6164CB942671ECCD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EDEF70DE65E9014C3AD1028FEA9E3D35 /* AbsintheUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AbsintheUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F34DD3AE0C69AEB796317585DD2A519A /* Pods-Absinthe.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Absinthe.debug.xcconfig"; path = "Target Support Files/Pods-Absinthe/Pods-Absinthe.debug.xcconfig"; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 		427A102ED22D635C5E0B3C22C7B12029 /* Absinthe */ = {
 			isa = PBXGroup;
 			children = (
+				E1E5D9E899DAEB7C90FB834E5F6EBD75 /* AbsinthePolicy.swift */,
 				E7E1AC6A5196ECAB6164CB942671ECCD /* AppDelegate.swift */,
 				C05FBFB2F0E22EAEBC5B98099D5F485E /* Assets.xcassets */,
 				C172372356F31B60A9F218710853D262 /* ContainerSetUp.swift */,
@@ -231,6 +234,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05E36357C969FB1349524452196E98C1 /* AbsinthePolicy.swift in Sources */,
 				DD8288EAAFFE1103849611C99A0AE32C /* AppDelegate.swift in Sources */,
 				55B93A6AB1A9B65807EAD7F52138C671 /* ContainerSetUp.swift in Sources */,
 				304DFDAB11588943050F33C943A60C16 /* Presenter.swift in Sources */,

--- a/Absinthe/Absinthe/AbsinthePolicy.swift
+++ b/Absinthe/Absinthe/AbsinthePolicy.swift
@@ -1,0 +1,14 @@
+//
+//  AbsinthePolicy.swift
+//  Absinthe
+//
+//  Created by User on 05/04/2020.
+//  Copyright © 2020 gonisoft. All rights reserved.
+//
+
+import Foundation
+import ViewModel
+
+enum AbsinthePolicy {
+    static let requiredPermissions: [PermissionType] = [.notification, .photo]
+}

--- a/Absinthe/Absinthe/ContainerSetUp.swift
+++ b/Absinthe/Absinthe/ContainerSetUp.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import AbsintheUI
-import ViewModel
-import Service
 import Swinject
+import AbsintheUI
+import Service
+import ViewModel
 
 extension AppDelegate {
     func createContainer() -> Container {
@@ -25,6 +25,7 @@ extension AppDelegate {
         // Intro
         container.register(IntroViewReactor.self) {
             IntroViewReactor(
+                requiredPermissions: AbsinthePolicy.requiredPermissions,
                 permissionService: $0.resolve(PermissionServiceType.self)!,
                 presenter: $0.resolve(Presenter.self)!
             )
@@ -36,6 +37,7 @@ extension AppDelegate {
         // Permission
         container.register(PermissionViewReactor.self) {
             PermissionViewReactor(
+                requiredPermissions: AbsinthePolicy.requiredPermissions,
                 permissionService: $0.resolve(PermissionServiceType.self)!,
                 presenter: $0.resolve(Presenter.self)!
             )

--- a/Absinthe/ViewModel/Model/PermissionType.swift
+++ b/Absinthe/ViewModel/Model/PermissionType.swift
@@ -12,9 +12,3 @@ public enum PermissionType {
     case photo
     case notification
 }
-
-public extension PermissionType {
-    static var requiredPermissions: [PermissionType] {
-        return [.notification, .photo]
-    }
-}

--- a/Absinthe/ViewModel/Reactor/IntroViewReactor.swift
+++ b/Absinthe/ViewModel/Reactor/IntroViewReactor.swift
@@ -21,13 +21,16 @@ public final class IntroViewReactor: Reactor {
 
     public struct State {}
 
+    private let requiredPermissions: [PermissionType]
     private let permissionService: PermissionServiceType
     private let presenter: PresenterType
 
     public init(
+        requiredPermissions: [PermissionType],
         permissionService: PermissionServiceType,
         presenter: PresenterType
     ) {
+        self.requiredPermissions = requiredPermissions
         self.permissionService = permissionService
         self.presenter = presenter
     }
@@ -35,7 +38,7 @@ public final class IntroViewReactor: Reactor {
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
             case .checkPermission:
-                return permissionService.hasPermissions(types: PermissionType.requiredPermissions)
+                return permissionService.hasPermissions(types: requiredPermissions)
                     .do(onSuccess: { [weak presenter] hasPermission in
                         let scene: Scene = hasPermission ? .gallery : .permission
                         presenter?.present(scene: scene)

--- a/Absinthe/ViewModel/Reactor/PermissionViewReactor.swift
+++ b/Absinthe/ViewModel/Reactor/PermissionViewReactor.swift
@@ -30,13 +30,16 @@ public final class PermissionViewReactor: Reactor {
 
     private let eventSubject = PublishSubject<Event>()
 
+    private let requiredPermissions: [PermissionType]
     private let permissionService: PermissionServiceType
     private let presenter: PresenterType
 
     public init(
+        requiredPermissions: [PermissionType],
         permissionService: PermissionServiceType,
         presenter: PresenterType
     ) {
+        self.requiredPermissions = requiredPermissions
         self.permissionService = permissionService
         self.presenter = presenter
     }
@@ -51,7 +54,7 @@ public final class PermissionViewReactor: Reactor {
                     if presented {
                         return .never()
                     } else {
-                        return ss.requestPermissionIfNeeded(permissions: PermissionType.requiredPermissions)
+                        return ss.requestPermissionIfNeeded(permissions: ss.requiredPermissions)
                     }
                 }
         }
@@ -85,7 +88,7 @@ public final class PermissionViewReactor: Reactor {
     }
 
     private func presentGallerySceneIfPermissionAuthorized() -> Single<Bool> {
-        return permissionService.hasPermissions(types: PermissionType.requiredPermissions)
+        return permissionService.hasPermissions(types: requiredPermissions)
             .do(onSuccess: { [weak self] hasAllPermissions in
                 if hasAllPermissions {
                     self?.presenter.present(scene: .gallery)


### PR DESCRIPTION
현재 수정은 필수 권한 목록을 Main모듈에서 정의하는데 이것이 Main에서 정의되어야할 부분인지 고민해보아야한다. 
ViewModel 모듈내 AbsinthePolicy같은 파일이 있어도 되지 않을까 고민이다.
추후 수정이 필요할 것으로 예상한다.